### PR TITLE
Blocked partition and formatting of code base.

### DIFF
--- a/bench.fut
+++ b/bench.fut
@@ -1,4 +1,3 @@
-
 import "lib/github.com/diku-dk/sorts/bitonic_sort"
 import "lib/github.com/diku-dk/sorts/merge_sort"
 import "lib/github.com/diku-dk/sorts/radix_sort"
@@ -17,7 +16,7 @@ entry radix_sort_i32 = radix_sort 32 i32.get_bit
 entry blocked_radix_sort_i32 = blocked_radix_sort 256 32 i32.get_bit
 entry partition_i32 = partition (< 0i32)
 entry blocked_partition_i32 = blocked_partition 256 (< 0i32)
-                               
+
 -- 64-bit keys
 -- ==
 -- entry: bitonic_sort_i64 merge_sort_i64 radix_sort_i64 blocked_radix_sort_i64 partition_i64 blocked_partition_i64

--- a/bench.fut
+++ b/bench.fut
@@ -1,10 +1,12 @@
+
 import "lib/github.com/diku-dk/sorts/bitonic_sort"
 import "lib/github.com/diku-dk/sorts/merge_sort"
 import "lib/github.com/diku-dk/sorts/radix_sort"
+import "lib/github.com/diku-dk/sorts/blocked_partition"
 
 -- 32-bit keys
 -- ==
--- entry: bitonic_sort_i32 merge_sort_i32 radix_sort_i32 blocked_radix_sort_i32
+-- entry: bitonic_sort_i32 merge_sort_i32 radix_sort_i32 blocked_radix_sort_i32 partition_i32 blocked_partition_i32
 -- random input { [100000]i32 }
 -- random input { [1000000]i32 }
 -- random input { [10000000]i32 }
@@ -13,10 +15,12 @@ entry bitonic_sort_i32 = bitonic_sort (i32.<=)
 entry merge_sort_i32 = merge_sort (i32.<=)
 entry radix_sort_i32 = radix_sort 32 i32.get_bit
 entry blocked_radix_sort_i32 = blocked_radix_sort 256 32 i32.get_bit
-
+entry partition_i32 = partition (< 0i32)
+entry blocked_partition_i32 = blocked_partition 256 (< 0i32)
+                               
 -- 64-bit keys
 -- ==
--- entry: bitonic_sort_i64 merge_sort_i64 radix_sort_i64 blocked_radix_sort_i64
+-- entry: bitonic_sort_i64 merge_sort_i64 radix_sort_i64 blocked_radix_sort_i64 partition_i64 blocked_partition_i64
 -- random input { [100000]i64 }
 -- random input { [1000000]i64 }
 -- random input { [10000000]i64 }
@@ -25,3 +29,11 @@ entry bitonic_sort_i64 = bitonic_sort (i64.<=)
 entry merge_sort_i64 = merge_sort (i64.<=)
 entry radix_sort_i64 = radix_sort 64 i64.get_bit
 entry blocked_radix_sort_i64 = blocked_radix_sort 256 64 i64.get_bit
+entry partition_i64 = partition (< 0i64)
+entry blocked_partition_i64 = blocked_partition 256 (< 0i64)
+
+-- Special 64-bit keys dataset for partition to show the performance
+-- improvement of blocked partition.
+-- ==
+-- entry: partition_i64 blocked_partition_i64
+-- random input { [500000000]i64 }

--- a/lib/github.com/diku-dk/sorts/bitonic_sort.fut
+++ b/lib/github.com/diku-dk/sorts/bitonic_sort.fut
@@ -8,48 +8,56 @@
 --
 -- * `merge_sort`@term@"merge_sort"
 
-local def log2 (n: i64) : i64 =
+local
+def log2 (n: i64) : i64 =
   let r = 0
-  let (r, _) = loop (r,n) while 1 < n do
-    let n = n / 2
-    let r = r + 1
-    in (r,n)
+  let (r, _) =
+    loop (r, n) while 1 < n do
+      let n = n / 2
+      let r = r + 1
+      in (r, n)
   in r
 
-local def ensure_pow_2 [n] 't ((<=): t -> t -> bool) (xs: [n]t): (*[]t, i64) =
-  if n == 0 then (copy xs, 0) else
-  let d = log2 n
-  in if n == 2**d
-     then (copy xs, d)
-     else let largest = reduce (\x y -> if x <= y then y else x) xs[0] xs
-          in (concat xs (replicate (2**(d+1) - n) largest),
-              d+1)
+local
+def ensure_pow_2 [n] 't ((<=): t -> t -> bool) (xs: [n]t) : (*[]t, i64) =
+  if n == 0
+  then (copy xs, 0)
+  else let d = log2 n
+       in if n == 2 ** d
+          then (copy xs, d)
+          else let largest = reduce (\x y -> if x <= y then y else x) xs[0] xs
+               in ( concat xs (replicate (2 ** (d + 1) - n) largest)
+                  , d + 1
+                  )
 
-local def kernel_par [n] 't ((<=): t -> t -> bool) (a: *[n]t) (p: i64) (q: i64) : *[n]t =
-  let d = 1 << (p-q) in
-  tabulate n (\i -> let a_i = a[i]
-                    let up1 = ((i >> p) & 2) == 0
-                    in
-                    if (i & d) == 0
-                    then let a_iord = a[i | d] in
-                         if a_iord <= a_i == up1
-                         then a_iord else a_i
-                    else let a_ixord = a[i ^ d] in
-                         if a_i <= a_ixord == up1
-                         then a_ixord else a_i)
+local
+def kernel_par [n] 't ((<=): t -> t -> bool) (a: *[n]t) (p: i64) (q: i64) : *[n]t =
+  let d = 1 << (p - q)
+  in tabulate n (\i ->
+                   let a_i = a[i]
+                   let up1 = ((i >> p) & 2) == 0
+                   in if (i & d) == 0
+                      then let a_iord = a[i | d]
+                           in if a_iord <= a_i == up1
+                              then a_iord
+                              else a_i
+                      else let a_ixord = a[i ^ d]
+                           in if a_i <= a_ixord == up1
+                              then a_ixord
+                              else a_i)
 
 -- | Sort an array in increasing order.
-def bitonic_sort [n] 't ((<=): t -> t -> bool) (xs: [n]t): *[n]t =
+def bitonic_sort [n] 't ((<=): t -> t -> bool) (xs: [n]t) : *[n]t =
   -- We need to pad the array so that its size is a power of 2.  We do
   -- this by first finding the largest element in the input, and then
   -- using that for the padding.  Then we know that the padding will
   -- all be at the end, so we can easily cut it off.
   let (xs, d) = ensure_pow_2 (<=) xs
   in (loop xs for i < d do
-        loop xs for j < i+1 do kernel_par (<=) xs i j)[:n]
+        loop xs for j < i + 1 do kernel_par (<=) xs i j)[:n]
 
 -- | Like `bitonic_sort`, but sort based on key function.
-def bitonic_sort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t): [n]t =
+def bitonic_sort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t) : [n]t =
   zip (map key xs) (iota n)
   |> bitonic_sort (\(x, _) (y, _) -> x <= y)
   |> map (\(_, i) -> xs[i])

--- a/lib/github.com/diku-dk/sorts/blocked_partition.fut
+++ b/lib/github.com/diku-dk/sorts/blocked_partition.fut
@@ -1,10 +1,11 @@
 -- | Blocked partition.
 --
--- This module contains 
+-- This module contains
 
-local def partition_block [n] 't
-                          (p: t -> bool)
-                          (xs: [n]t) : ([n]t, [2]i64, [2]i16) =
+local
+def partition_block [n] 't
+                    (p: t -> bool)
+                    (xs: [n]t) : ([n]t, [2]i64, [2]i16) =
   let pairwise op (a1, b1) (a2, b2) = (a1 `op` a2, b1 `op` b2)
   let flags =
     xs
@@ -26,16 +27,18 @@ local def partition_block [n] 't
      , [0, na]
      )
 
-local def exscan op ne xs =
+local
+def exscan op ne xs =
   let s =
     scan op ne xs
     |> rotate (-1)
   let s[0] = ne
   in s
 
-local def blocked_partition_auxiliary [n] [m] [r] 't
-                                      (p: t -> bool)
-                                      (xs: [n * m + r]t) : ([n * m + r]t, i64) =
+local
+def blocked_partition_auxiliary [n] [m] [r] 't
+                                (p: t -> bool)
+                                (xs: [n * m + r]t) : ([n * m + r]t, i64) =
   let (blocks, rest) = split xs
   let (partitioned_rest, hist_rest, offsets_rest) =
     partition_block p rest

--- a/lib/github.com/diku-dk/sorts/blocked_partition.fut
+++ b/lib/github.com/diku-dk/sorts/blocked_partition.fut
@@ -1,0 +1,87 @@
+-- | Blocked partition.
+--
+-- This module contains 
+
+local def partition_block [n] 't
+                          (p: t -> bool)
+                          (xs: [n]t) : ([n]t, [2]i64, [2]i16) =
+  let pairwise op (a1, b1) (a2, b2) = (a1 `op` a2, b1 `op` b2)
+  let flags =
+    xs
+    |> map (\x ->
+              ( i16.bool <| not <| p x
+              , i16.bool <| p x
+              ))
+  let offsets = scan (pairwise (+)) (0, 0) flags
+  let (na, nb) = if n == 0 then (0, 0) else last offsets
+  let f bin (a, b) =
+    i64.i16 ((-1)
+             + a * (i16.bool (bin == 0))
+             + na * (i16.bool (bin > 0))
+             + b * (i16.bool (bin == 1)))
+  let bins = xs |> map (i16.bool <-< p)
+  let is = map2 f bins offsets
+  in ( scatter (copy xs) is xs
+     , map i64.i16 [na, nb]
+     , [0, na]
+     )
+
+local def exscan op ne xs =
+  let s =
+    scan op ne xs
+    |> rotate (-1)
+  let s[0] = ne
+  in s
+
+local def blocked_partition_auxiliary [n] [m] [r] 't
+                                      (p: t -> bool)
+                                      (xs: [n * m + r]t) : ([n * m + r]t, i64) =
+  let (blocks, rest) = split xs
+  let (partitioned_rest, hist_rest, offsets_rest) =
+    partition_block p rest
+  let (partitioned_blocks, hist_blocks, offsets_blocks) =
+    unflatten blocks
+    |> map (partition_block p)
+    |> unzip3
+  let histograms = hist_blocks ++ [hist_rest]
+  let partitions = sized (n * m + r) (flatten partitioned_blocks ++ partitioned_rest)
+  let old_offsets = offsets_blocks ++ [offsets_rest]
+  let new_offsets =
+    histograms
+    |> transpose
+    |> flatten
+    |> exscan (+) 0
+    |> unflatten
+    |> transpose
+  let is =
+    tabulate (n * m + r) (\i ->
+                            let elem = partitions[i]
+                            let bin = i64.bool <| p elem
+                            let block_idx = i / m
+                            let new_offset = new_offsets[block_idx][bin]
+                            let old_block_offset = i64.i16 old_offsets[block_idx][bin]
+                            let old_offset = m * block_idx + old_block_offset
+                            let idx = (i - old_offset) + new_offset
+                            in idx)
+  let out = replicate (n * m + r) xs[0] :> [n * m + r]t
+  in (scatter out is partitions, new_offsets[0][1])
+
+-- | A blocked partition, this leads to a speed up compared to the
+-- partition given in Futharks prelude. It works much like a blocked
+-- radix sort [1] but just with one bit. It probably leads to worse
+-- fusion and is only worth using for large enough inputs.
+--
+-- [1] N. Satish, M. Harris and M. Garland, "Designing efficient
+-- sorting algorithms for manycore GPUs," 2009 IEEE International
+-- Symposium on Parallel & Distributed Processing, Rome, Italy, 2009,
+-- pp. 1-10, doi: 10.1109/IPDPS.2009.5161005.
+def blocked_partition [n] 't
+                      (block: i16)
+                      (p: t -> bool)
+                      (xs: [n]t) : ?[k].([k]t, [n - k]t) =
+  let block = i64.i16 block
+  let n_blocks = n / block
+  let rest = n % block
+  let xs = sized (n_blocks * block + rest) xs
+  let (ys, o) = blocked_partition_auxiliary (not <-< p) xs
+  in (ys[0:o], ys[o:n])

--- a/lib/github.com/diku-dk/sorts/blocked_partition_tests.fut
+++ b/lib/github.com/diku-dk/sorts/blocked_partition_tests.fut
@@ -1,0 +1,16 @@
+import "blocked_partition"
+
+-- ==
+-- entry: test_blocked_partition
+-- random input { [1000]i32 }
+-- output { true }
+entry test_blocked_partition [n] (xs: [n]i32) =
+  let (a0, a1) = blocked_partition 256 (< 0) xs
+  let (b0, b1) = partition (< 0) xs
+  let l0 = length a0
+  let l1 = length a1
+  let a0 = sized l0 a0
+  let b0 = sized l0 b0
+  let a1 = sized l1 a1
+  let b1 = sized l1 b1
+  in (map2 (==) a0 b0 |> and) && (map2 (==) a1 b1 |> and)

--- a/lib/github.com/diku-dk/sorts/bubble_sort.fut
+++ b/lib/github.com/diku-dk/sorts/bubble_sort.fut
@@ -5,21 +5,24 @@
 -- non-sorted data.
 
 -- | Parallel bubble sort.  Runs with *O(n^2)* work and *O(n^2)* depth.
-def bubble_sort [n] 't ((<=): t -> t -> bool) (xs: [n]t): [n]t =
+def bubble_sort [n] 't ((<=): t -> t -> bool) (xs: [n]t) : [n]t =
   let f b xs i =
-    let dir = if i%2 == 0 then b else -b
+    let dir = if i % 2 == 0 then b else -b
     let j = i + dir
-    let cmp x y = if dir == 1 then x <= y
-                  else ! (x <= y)
+    let cmp x y =
+      if dir == 1
+      then x <= y
+      else !(x <= y)
     in if j >= 0 && j < n && (xs[j] `cmp` xs[i])
-       then (true, xs[j]) else (false, xs[i])
+       then (true, xs[j])
+       else (false, xs[i])
   let iter xs b =
     let (changed, xs) = tabulate n (f b xs) |> unzip
     in (xs, -b, or changed)
   in (loop (xs, b, continue) = (xs, 1, true) while continue do iter xs b).0
 
 -- | Like `bubble_sort`@term, but sort based on key function.
-def bubble_sort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t): [n]t =
+def bubble_sort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t) : [n]t =
   zip (map key xs) (iota n)
   |> bubble_sort (\(x, _) (y, _) -> x <= y)
   |> map (\(_, i) -> xs[i])

--- a/lib/github.com/diku-dk/sorts/insertion_sort.fut
+++ b/lib/github.com/diku-dk/sorts/insertion_sort.fut
@@ -1,8 +1,7 @@
 -- | A sequential implementation of insertion sort.
 
-
 local
-def swap 't [n] (i: i64) (j: i64) (xs: *[n]t): *[n]t =
+def swap 't [n] (i: i64) (j: i64) (xs: *[n]t) : *[n]t =
   -- Need copies to prevent the uniqueness checker from getting
   -- cranky.
   let xi = copy xs[i]
@@ -11,18 +10,20 @@ def swap 't [n] (i: i64) (j: i64) (xs: *[n]t): *[n]t =
   in xs
 
 -- | Insertion sort.  Runs with *O(n^2)* work and *O(n^2)* depth.
-def insertion_sort [n] 't ((<=): t -> t -> bool) (xs: [n]t): *[n]t =
+def insertion_sort [n] 't ((<=): t -> t -> bool) (xs: [n]t) : *[n]t =
   -- Make a copy of the array so we can operate in-place.
-  loop xs = copy xs for i in 1..< i64.max n 1 do
+  loop xs = copy xs
+  for i in 1..<i64.max n 1 do
     -- Construct our own greather-than function out of <=.
     let gt x y = !(x <= y)
-    let (_, xs') = loop (j, xs) = (i, xs) while j > 0 && (xs[j-1] `gt` xs[j]) do
-                     (j-1, swap j (j-1) xs)
+    let (_, xs') =
+      loop (j, xs) = (i, xs)
+      while j > 0 && (xs[j - 1] `gt` xs[j]) do
+        (j - 1, swap j (j - 1) xs)
     in xs'
 
-
 -- | Like `insertion_sort`, but sort based on key function.
-def insertion_sort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t): [n]t =
+def insertion_sort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t) : [n]t =
   zip (map key xs) (iota n)
   |> insertion_sort (\(x, _) (y, _) -> x <= y)
   |> map (\(_, i) -> xs[i])

--- a/lib/github.com/diku-dk/sorts/merge_sort.fut
+++ b/lib/github.com/diku-dk/sorts/merge_sort.fut
@@ -2,7 +2,6 @@
 --
 -- Author: Sam Westrick <shwestrick@gmail.com.
 
-
 ------------------------------------------------------------------------------
 -- Double binary search:
 -- Split sorted sequences s and t into (s1, s2) and (t1, t2) such that the
@@ -27,64 +26,49 @@ def split_count 'a (leq: a -> a -> bool) (s: []a) (t: []a) k : (i64, i64) =
   let normalize ((slo, shi), (tlo, thi), count) =
     let slo_orig = slo
     let tlo_orig = tlo
-
     -- maybe count is small
     let shi = i64.min shi (slo + count)
     let thi = i64.min thi (tlo + count)
-
     -- maybe count is large
-    let slack = (shi-slo) + (thi-tlo) - count
-    let slack = i64.min slack (shi-slo)
-    let slack = i64.min slack (thi-tlo)
-
+    let slack = (shi - slo) + (thi - tlo) - count
+    let slack = i64.min slack (shi - slo)
+    let slack = i64.min slack (thi - tlo)
     let slo = i64.max slo (shi - slack)
     let tlo = i64.max tlo (thi - slack)
-
     let count = count - (slo - slo_orig) - (tlo - tlo_orig)
-    in
-    ((slo, shi), (tlo, thi), count)
-
+    in ((slo, shi), (tlo, thi), count)
   let step ((slo, shi), (tlo, thi), count) =
-    if shi-slo <= 0 then
-      ((slo, shi), (tlo+count, thi), 0)
-    else if thi-tlo <= 0 then
-      ((slo+count, shi), (tlo, thi), 0)
-    else if count == 1 then
-      if leq t[tlo] s[slo] then
-        ((slo, shi), (tlo+1, thi), 0)
-      else
-        ((slo+1, shi), (tlo, thi), 0)
-    else
-    let m = count / 2
-    let n = count - m
+    if shi - slo <= 0
+    then ((slo, shi), (tlo + count, thi), 0)
+    else if thi - tlo <= 0
+    then ((slo + count, shi), (tlo, thi), 0)
+    else if count == 1
+    then if leq t[tlo] s[slo]
+         then ((slo, shi), (tlo + 1, thi), 0)
+         else ((slo + 1, shi), (tlo, thi), 0)
+    else let m = count / 2
+         let n = count - m
+         --  |------|x|-------|
+         --  ^      ^         ^
+         -- slo   slo+m      shi
+         --
+         --  |------|y|-------|
+         --  ^        ^       ^
+         -- tlo     tlo+n    thi
+         --
 
-    --  |------|x|-------|
-    --  ^      ^         ^
-    -- slo   slo+m      shi
-    --
-    --  |------|y|-------|
-    --  ^        ^       ^
-    -- tlo     tlo+n    thi
-    --
-
-    let leq_y_x =
-      n == 0 ||
-      slo+m >= shi ||
-      leq t[tlo+n-1] s[slo+m]
-    in
-    if leq_y_x then
-      ((slo, shi), (tlo+n, thi), count-n)
-    else
-      ((slo, shi), (tlo, tlo+n), count)
-
+         let leq_y_x =
+           n == 0
+           || slo + m >= shi
+           || leq t[tlo + n - 1] s[slo + m]
+         in if leq_y_x
+            then ((slo, shi), (tlo + n, thi), count - n)
+            else ((slo, shi), (tlo, tlo + n), count)
   let ((slo, _), (tlo, _), _) =
     loop (ss, tt, count) = normalize ((0, length s), (0, length t), k)
     while count > 0 do
       normalize (step (ss, tt, count))
-
-  in
-  (slo, tlo)
-
+  in (slo, tlo)
 
 ------------------------------------------------------------------------------
 -- `merge_sequential leq s t n` merges sorted sequences `s` and `t` with the
@@ -99,17 +83,15 @@ local
 def merge_sequential 'a (leq: a -> a -> bool) (s: []a) (t: []a) n : *[n]a =
   let dummy = if length s > 0 then head s else head t
   let (_, data) =
-    loop (i, data) = (0, replicate n dummy) for k < n do
-      let j = k-i
+    loop (i, data) = (0, replicate n dummy)
+    for k < n do
+      let j = k - i
       let (i, x) =
-        if j == length t || (i < length s && leq s[i] t[j]) then
-          (i+1, s[i])
-        else
-          (i, t[j])
-      in
-      (i, data with [k] = x)
-  in
-  data
+        if j == length t || (i < length s && leq s[i] t[j])
+        then (i + 1, s[i])
+        else (i, t[j])
+      in (i, data with [k] = x)
+  in data
 
 ------------------------------------------------------------------------------
 -- `merge_adjacent leq s mid block_size` merges s[:mid] with s[mid:]
@@ -141,18 +123,16 @@ def merge_sequential 'a (leq: a -> a -> bool) (s: []a) (t: []a) n : *[n]a =
 
 local
 def merge_adjacent 'a [n] (leq: a -> a -> bool) (s: [n]a) mid block_size : *[n]a =
-  if n < 10 then
-    merge_sequential leq s[:mid] s[mid:] n
-  else
-  let num_blocks = assert (n % block_size == 0) (n / block_size)
-  let splitters =
-    tabulate (1+num_blocks) (\i -> split_count leq s[:mid] s[mid:] (i * block_size))
-  let block b : [block_size]a =
-    let (slo, tlo) = splitters[b]
-    let (shi, thi) = splitters[b+1]
-    in merge_sequential leq s[slo:shi] s[mid+tlo:mid+thi] block_size
-  in
-  take n (flatten (tabulate num_blocks block))
+  if n < 10
+  then merge_sequential leq s[:mid] s[mid:] n
+  else let num_blocks = assert (n % block_size == 0) (n / block_size)
+       let splitters =
+         tabulate (1 + num_blocks) (\i -> split_count leq s[:mid] s[mid:] (i * block_size))
+       let block b: [block_size]a =
+         let (slo, tlo) = splitters[b]
+         let (shi, thi) = splitters[b + 1]
+         in merge_sequential leq s[slo:shi] s[mid + tlo:mid + thi] block_size
+       in take n (flatten (tabulate num_blocks block))
 
 ------------------------------------------------------------------------------
 -- `small_insertion_sort leq s` is faster than merge sort for very small
@@ -160,36 +140,32 @@ def merge_adjacent 'a [n] (leq: a -> a -> bool) (s: [n]a) mid block_size : *[n]a
 
 local
 def small_insertion_sort 't [n] (leq: t -> t -> bool) (s: *[n]t) : *[n]t =
-  if n <= 1 then s else
-  let gt x y = !(leq x y)
-  in
-  loop s for i in 0...(n-2) do
-    let (s, _) =
-      loop (s, j) = (s, i)
-      while j >= 0 && gt s[j] s[j+1] do
-        let tmp = copy s[j]
-        let s = s with [j] = copy s[j+1]
-        let s = s with [j+1] = tmp
-        in
-        (s, j-1)
-    in
-    s
-
+  if n <= 1
+  then s
+  else let gt x y = !(leq x y)
+       in loop s for i in 0...(n - 2) do
+            let (s, _) =
+              loop (s, j) = (s, i)
+              while j >= 0 && gt s[j] s[j + 1] do
+                let tmp = copy s[j]
+                let s = s with [j] = copy s[j + 1]
+                let s = s with [j + 1] = tmp
+                in (s, j - 1)
+            in s
 
 -----------------------------------------------------------------------------
 -- a couple utilities
 
 local
 def smallest_pow_2_geq_than k =
-  loop (x: i64) = 1 while x < k do 2*x
+  loop (x: i64) = 1 while x < k do 2 * x
 
 local
 def greatest_divisor_leq_than upper_bound n =
   -- find smallest d such that d|n and n/d <= upper_bound
   let upper_bound = assert (upper_bound >= 1) upper_bound
-  let d = loop (d: i64) = 1 while n/d > upper_bound || n%d != 0 do d+1
-  in n/d
-
+  let d = loop (d: i64) = 1 while n / d > upper_bound || n % d != 0 do d + 1
+  in n / d
 
 -- | Work-efficient parallel mergesort:
 --   `merge_sort_with_params {max_block_size, max_merge_block_size} leq s`
@@ -223,61 +199,50 @@ def merge_sort_with_params [n] 't {max_block_size, max_merge_block_size} (leq: t
   -- `max_merge_block_size`. We need `merge_block_size` to be a divisor of
   -- every 2^i * block_size for i >= 1. So, we pick the greatest divisor of
   -- 2*block_size that satisfies merge_block_size <= max_merge_block_size.
-  if length s <= 1 then s else
-
-  let max_block_size = i64.max 1 max_block_size
-  let max_merge_block_size = i64.max 1 max_merge_block_size
-
-  let min_num_blocks = 1 + (n-1) / max_block_size
-  let num_blocks = smallest_pow_2_geq_than min_num_blocks
-
-  let block_size = 1 + (n-1) / num_blocks
-  let padded_n = block_size * num_blocks
-
-  let merge_block_size =
-    greatest_divisor_leq_than max_merge_block_size (2*block_size)
-
-  let max_elem = reduce (\a b -> if leq a b then b else a) s[0] s
-
-  let sorted_blocks =
-    flatten (tabulate num_blocks (\i ->
-      let block = tabulate block_size (\j ->
-        let k = i*block_size + j
-        in if k < n then s[k] else max_elem)
-      in
-      small_insertion_sort leq block))
-
-  let (data, _) =
-    loop (data, stride) = (sorted_blocks, block_size)
-    while stride < padded_n do
-      let next_stride = 2 * stride
-      let num_merges = padded_n / next_stride
-      let data =
-        flatten (tabulate num_merges (\mi ->
-          let start = mi * next_stride
-          let piece = take next_stride (drop start data)
-          in
-          merge_adjacent leq piece stride merge_block_size))
-      in
-      (data, next_stride)
-
-  in
-  take n data
+  if length s <= 1
+  then s
+  else let max_block_size = i64.max 1 max_block_size
+       let max_merge_block_size = i64.max 1 max_merge_block_size
+       let min_num_blocks = 1 + (n - 1) / max_block_size
+       let num_blocks = smallest_pow_2_geq_than min_num_blocks
+       let block_size = 1 + (n - 1) / num_blocks
+       let padded_n = block_size * num_blocks
+       let merge_block_size =
+         greatest_divisor_leq_than max_merge_block_size (2 * block_size)
+       let max_elem = reduce (\a b -> if leq a b then b else a) s[0] s
+       let sorted_blocks =
+         flatten (tabulate num_blocks (\i ->
+                                         let block =
+                                           tabulate block_size (\j ->
+                                                                  let k = i * block_size + j
+                                                                  in if k < n then s[k] else max_elem)
+                                         in small_insertion_sort leq block))
+       let (data, _) =
+         loop (data, stride) = (sorted_blocks, block_size)
+         while stride < padded_n do
+           let next_stride = 2 * stride
+           let num_merges = padded_n / next_stride
+           let data =
+             flatten (tabulate num_merges (\mi ->
+                                             let start = mi * next_stride
+                                             let piece = take next_stride (drop start data)
+                                             in merge_adjacent leq piece stride merge_block_size))
+           in (data, next_stride)
+       in take n data
 
 -----------------------------------------------------------------------------
 
 def merge_sort [n] 't (leq: t -> t -> bool) (s: [n]t) : [n]t =
   -- Note: this selection of parameters seems to work well in practice, but
   -- could be investigated more carefully.
-  merge_sort_with_params {max_block_size=20, max_merge_block_size=8} leq s
+  merge_sort_with_params {max_block_size = 20, max_merge_block_size = 8} leq s
 
 def merge_sort_by_key [n] 't 'k (key: t -> k) (leq: k -> k -> bool) (s: [n]t) : [n]t =
   zip (map key s) (iota n)
-    |> merge_sort (\(x, _) (y, _) -> leq x y)
-    |> map (\(_, i) -> s[i])
-
+  |> merge_sort (\(x, _) (y, _) -> leq x y)
+  |> map (\(_, i) -> s[i])
 
 def merge_sort_with_params_by_key [n] 't 'k params key leq (s: [n]t) : [n]t =
   zip (map key s) (iota n)
-    |> merge_sort_with_params params (\(x, _) (y, _) -> leq x y)
-    |> map (\(_, i) -> s[i])
+  |> merge_sort_with_params params (\(x, _) (y, _) -> leq x y)
+  |> map (\(_, i) -> s[i])

--- a/lib/github.com/diku-dk/sorts/merge_sort_tests.fut
+++ b/lib/github.com/diku-dk/sorts/merge_sort_tests.fut
@@ -4,7 +4,7 @@ import "merge_sort"
 
 -- picking small block sizes should stress all codepaths within
 -- merge_sort, even on small inputs
-let params = {max_block_size = 2i64, max_merge_block_size = 2i64}
+def params = {max_block_size = 2i64, max_merge_block_size = 2i64}
 
 -- ==
 -- entry: sort_i32

--- a/lib/github.com/diku-dk/sorts/quick_sort.fut
+++ b/lib/github.com/diku-dk/sorts/quick_sort.fut
@@ -4,77 +4,89 @@
 
 local import "../segmented/segmented"
 
-local def segmented_replicate [n] 't (reps:[n]i64) (vs:[n]t) : []t =
+local
+def segmented_replicate [n] 't (reps: [n]i64) (vs: [n]t) : []t =
   let idxs = replicated_iota reps
   in map (\i -> vs[i]) idxs
 
-local def info 't ((<=): t -> t -> bool) (x:t) (y:t) : i64 =
-  if x <= y then
-     if y <= x then 0 else -1
+local
+def info 't ((<=): t -> t -> bool) (x: t) (y: t) : i64 =
+  if x <= y
+  then if y <= x then 0 else -1
   else 1
 
-local def tripit (x: i64): (i64,i64,i64) =
-  if x < 0 then (1,0,0)
-  else if x > 0 then (0,0,1) else (0,1,0)
+local
+def tripit (x: i64) : (i64, i64, i64) =
+  if x < 0
+  then (1, 0, 0)
+  else if x > 0 then (0, 0, 1) else (0, 1, 0)
 
-local def tripadd (a1:i64,e1:i64,b1:i64) (a2,e2,b2) =
-  (a1+a2,e1+e2,b1+b2)
+local
+def tripadd (a1: i64, e1: i64, b1: i64) (a2, e2, b2) =
+  (a1 + a2, e1 + e2, b1 + b2)
 
-local type sgm = {start:i64,sz:i64}  -- segment
+local type sgm = {start: i64, sz: i64}
 
-local def step [n][k] 't ((<=): t -> t -> bool) (xs:*[n]t) (sgms:[k]sgm) : (*[n]t,[]sgm) =
+-- segment
+
+local
+def step [n] [k] 't ((<=): t -> t -> bool) (xs: *[n]t) (sgms: [k]sgm) : (*[n]t, []sgm) =
   --let _ = trace {NEW_STEP=()}
 
   -- find a pivot for each segment
-  let pivots : []t = map (\sgm -> xs[sgm.start + sgm.sz/2]) sgms
-  let sgms_szs : []i64 = map (\sgm -> sgm.sz) sgms
+  let pivots: []t = map (\sgm -> xs[sgm.start + sgm.sz / 2]) sgms
+  let sgms_szs: []i64 = map (\sgm -> sgm.sz) sgms
   let [m] (idxs: [m]i64) = replicated_iota sgms_szs
-
   -- find the indexes into values in segments; after a value equal to
   -- a pivot has moved, it will no longer be part of a segment (it
   -- need not be moved again).
   let is =
-    let is1 = segmented_replicate sgms_szs (map (\x -> x.start) sgms)
-              :> [m]i64
+    let is1 =
+      segmented_replicate sgms_szs (map (\x -> x.start) sgms)
+      :> [m]i64
     let fs = map2 (!=) is1 (rotate (-1) is1)
     let is2 = segmented_iota fs
     in map2 (+) is1 is2
-
   -- for each such value, how does it compare to the pivot associated
   -- with the segment?
-  let infos : []i64 = map2 (\idx i -> info (<=) xs[i] pivots[idx])
-                           idxs is
-  let orders : [](i64,i64,i64) = map tripit infos
-
+  let infos: []i64 =
+    map2 (\idx i -> info (<=) xs[i] pivots[idx])
+         idxs
+         is
+  let orders: [](i64, i64, i64) = map tripit infos
   -- compute segment descriptor
   let flags =
     let flags = map2 (!=) idxs (rotate (-1) idxs)
     in flags with [0] = true
-
   -- compute partition sizes for each segment
-  let pszs = segmented_reduce tripadd (0,0,0) flags orders :> [k](i64,i64,i64)
-
+  let pszs = segmented_reduce tripadd (0, 0, 0) flags orders :> [k](i64, i64, i64)
   -- compute the new segments
   let sgms' =
-    map2 (\(sgm:sgm) (a,e,b) -> [{start=sgm.start,sz=a},
-                                 {start=sgm.start+a+e,sz=b}]) sgms pszs
+    map2 (\(sgm: sgm) (a, e, b) ->
+            [ {start = sgm.start, sz = a}
+            , {start = sgm.start + a + e, sz = b}
+            ])
+         sgms
+         pszs
     |> flatten
     |> filter (\sgm -> sgm.sz > 1)
-
   -- compute the new positions of the values in the present segments
-  let newpos : []i64 =
-    let where : [](i64,i64,i64) = segmented_scan tripadd (0,0,0) flags orders
-    in map3 (\i (a,e,b) info ->
-             let (x,y,_) = pszs[i]
-             let s = sgms[i].start
-             in if info < 0 then s+a-1
-                else if info > 0 then s+b-1+x+y
-                else s+e-1+x)
-            idxs where infos
-
+  let newpos: []i64 =
+    let where: [](i64, i64, i64) = segmented_scan tripadd (0, 0, 0) flags orders
+    in map3 (\i (a, e, b) info ->
+               let (x, y, _) = pszs[i]
+               let s = sgms[i].start
+               in if info < 0
+                  then s + a - 1
+                  else if info > 0
+                  then s + b - 1 + x + y
+                  else s + e - 1 + x)
+            idxs
+            where
+            infos
   let vs = map (\i -> xs[i]) is
   let xs' = scatter xs newpos vs
-  in (xs',sgms')
+  in (xs', sgms')
 
 -- | Quicksort. Given a comparison function (<=) and an array of
 -- elements, `qsort (<=) xs` returns an array with the elements in
@@ -83,14 +95,15 @@ local def step [n][k] 't ((<=): t -> t -> bool) (xs:*[n]t) (sgms:[k]sgm) : (*[n]
 -- work complexity *O(n^2)*, and an average case work complexity of
 -- *O(n log n)*. It has best depth complexity *O(1)*, worst depth
 -- complexity *O(n)* and average depth complexity *O(log n)*.
-
-def qsort [n] 't ((<=): t -> t -> bool) (xs:[n]t) : [n]t =
-  if n < 2 then xs
-  else (loop (xs,mms) = (copy xs,[{start=0,sz=n}]) while length mms > 0 do
+def qsort [n] 't ((<=): t -> t -> bool) (xs: [n]t) : [n]t =
+  if n < 2
+  then xs
+  else (loop (xs, mms) = (copy xs, [{start = 0, sz = n}])
+        while length mms > 0 do
           step (<=) xs mms).0
 
 -- | Like `qsort`@term, but sort based on key function.
-def qsort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t): [n]t =
+def qsort_by_key [n] 't 'k (key: t -> k) ((<=): k -> k -> bool) (xs: [n]t) : [n]t =
   zip (map key xs) (iota n)
   |> qsort (\(x, _) (y, _) -> x <= y)
   |> map (\(_, i) -> xs[i])

--- a/lib/github.com/diku-dk/sorts/radix_sort_tests.fut
+++ b/lib/github.com/diku-dk/sorts/radix_sort_tests.fut
@@ -44,37 +44,35 @@ entry sort_perm_f32 [n] (xs: [n]f32) =
   zip xs (iota n)
   |> radix_sort_float_by_key (.0) f32.num_bits f32.get_bit
   |> map ((.1) >-> i32.i64)
-  
+
 -- ==
 -- entry: is_sorted
 -- random input { [10][50]u64 }
 -- output { true }
 
-entry is_sorted [n] (arrs : [][n]u64) : bool =
-  all (
-    \arr ->
-      let result = radix_sort u64.num_bits u64.get_bit arr
-      in tabulate n (\i -> i == 0 || result[i - 1] <= result[i])
-     |> and
-  ) arrs
+entry is_sorted [n] (arrs: [][n]u64) : bool =
+  all (\arr ->
+         let result = radix_sort u64.num_bits u64.get_bit arr
+         in tabulate n (\i -> i == 0 || result[i - 1] <= result[i])
+            |> and)
+      arrs
 
 -- ==
 -- entry: is_stable
 -- random input { [10][50]u8 }
 -- output { true }
 
-entry is_stable [n] (arrs : [][n]u8) : bool =
-  all (
-    \arr ->
-      let (keys, idx) =
-        map (% 5) arr
-        |> flip zip (iota n)
-        |> radix_sort_by_key (.0) u8.num_bits u8.get_bit
-        |> unzip
-      in tabulate n (\i -> i == 0 || keys[i - 1] != keys[i] || idx[i - 1] < idx[i])
-         |> and
-  ) arrs
-  
+entry is_stable [n] (arrs: [][n]u8) : bool =
+  all (\arr ->
+         let (keys, idx) =
+           map (% 5) arr
+           |> flip zip (iota n)
+           |> radix_sort_by_key (.0) u8.num_bits u8.get_bit
+           |> unzip
+         in tabulate n (\i -> i == 0 || keys[i - 1] != keys[i] || idx[i - 1] < idx[i])
+            |> and)
+      arrs
+
 -- ==
 -- entry: blocked_sort_i32
 -- input { [5,4,3,2,1,0,-1,-2] }
@@ -126,27 +124,25 @@ entry blocked_sort_perm_f32 [n] (xs: [n]f32) =
 -- random input { [10][50]u64 }
 -- output { true }
 
-entry blocked_is_sorted [n] (arrs : [][n]u64) : bool =
-  all (
-    \arr ->
-      let result = blocked_radix_sort 3 u64.num_bits u64.get_bit arr
-      in tabulate n (\i -> i == 0 || result[i - 1] <= result[i])
-     |> and
-  ) arrs
+entry blocked_is_sorted [n] (arrs: [][n]u64) : bool =
+  all (\arr ->
+         let result = blocked_radix_sort 3 u64.num_bits u64.get_bit arr
+         in tabulate n (\i -> i == 0 || result[i - 1] <= result[i])
+            |> and)
+      arrs
 
 -- ==
 -- entry: blocked_is_stable
 -- random input { [10][50]u8 }
 -- output { true }
 
-entry blocked_is_stable [n] (arrs : [][n]u8) : bool =
-  all (
-    \arr ->
-      let (keys, idx) =
-        map (% 5) arr
-        |> flip zip (iota n)
-        |> blocked_radix_sort_by_key 3 (.0) u8.num_bits u8.get_bit
-        |> unzip
-      in tabulate n (\i -> i == 0 || keys[i - 1] != keys[i] || idx[i - 1] < idx[i])
-         |> and
-  ) arrs
+entry blocked_is_stable [n] (arrs: [][n]u8) : bool =
+  all (\arr ->
+         let (keys, idx) =
+           map (% 5) arr
+           |> flip zip (iota n)
+           |> blocked_radix_sort_by_key 3 (.0) u8.num_bits u8.get_bit
+           |> unzip
+         in tabulate n (\i -> i == 0 || keys[i - 1] != keys[i] || idx[i - 1] < idx[i])
+            |> and)
+      arrs


### PR DESCRIPTION
I needed a break from looking at the Futhark compiler so I did some spring cleaning @athas.
I have formatted the code base and it seems fine and moved the `block_partition` from containers to this library.
`block_partition` does give a speed up compared  to `partition` of a factor two on a 4070 super for large inputs of 500 million i64.
This version of partition might become obsolete with scan scatter fusion or the optimization Cosmin is working.